### PR TITLE
Find compilers in `packages.yaml`

### DIFF
--- a/stackinator/etc/envvars.py
+++ b/stackinator/etc/envvars.py
@@ -447,13 +447,19 @@ def view_impl(args):
 
         with open(args.compilers, "r") as file:
             data = yaml.safe_load(file)
-        compilers = [c["compiler"] for c in data["compilers"]]
+
+        compilers = []
+        for p in data["packages"].values():
+            for e in p["externals"]:
+                c = e["extra_attributes"]["compilers"]
+                if c is not None:
+                    compilers.append(c)
 
         compiler_paths = []
         for c in compilers:
-            local_paths = set([os.path.dirname(v) for _, v in c["paths"].items() if v is not None])
+            local_paths = set([os.path.dirname(v) for _, v in c.items() if v is not None])
             compiler_paths += local_paths
-            print(f'adding compiler {c["spec"]} -> {[p for p in local_paths]}')
+            print(f'adding compiler {c} -> {[p for p in local_paths]}')
 
         envvars.set_list("PATH", compiler_paths, EnvVarOp.PREPEND)
 
@@ -577,7 +583,7 @@ if __name__ == "__main__":
         "--prefix_paths", help="a list of relative prefix path searchs of the form X=y:z,Y=p:q", default="", type=str
     )
     # only add compilers if this argument is passed
-    view_parser.add_argument("--compilers", help="path of the compilers.yaml file", type=str, default=None)
+    view_parser.add_argument("--compilers", help="path of the packages.yaml file", type=str, default=None)
 
     uenv_parser = subparsers.add_parser(
         "uenv",

--- a/stackinator/templates/Makefile.environments
+++ b/stackinator/templates/Makefile.environments
@@ -33,7 +33,7 @@ all:{% for env in environments %} {{ env }}/generated/build_cache{% endfor %}
 {{ env }}/generated/view_config: {{ env }}/generated/env
 {% if config.view %}
 	$(SPACK) env activate --with-view default --sh ./{{ env }} > $(STORE)/env/{{ config.view.name }}/activate.sh
-	$(BUILD_ROOT)/envvars.py view {% if config.view.extra.add_compilers %}--compilers=./{{ env }}/compilers.yaml {% endif %} --prefix_paths="{{ config.view.extra.prefix_string }}" $(STORE)/env/{{ config.view.name }} $(BUILD_ROOT)
+	$(BUILD_ROOT)/envvars.py view {% if config.view.extra.add_compilers %}--compilers=./{{ env }}/packages.yaml {% endif %} --prefix_paths="{{ config.view.extra.prefix_string }}" $(STORE)/env/{{ config.view.name }} $(BUILD_ROOT)
 {% endif %}
 	touch $@
 


### PR DESCRIPTION
Targeting https://github.com/eth-cscs/stackinator/pull/215. @albestro this is just the first minimal change that I did to get stackinator to find compilers from `packages.yaml`. I think there's plenty of room for improvement, and many things I haven't considered, but I think it makes sense to merge to the PR ASAP and we can iterate further on your PR. I'm opening this to avoid having my local changes linger too long on my local setup. I'll keep opening new PRs as I find more required changes.